### PR TITLE
fix request body

### DIFF
--- a/Sources/WebFoundation/Utils/JSTypedArray+Conversions.swift
+++ b/Sources/WebFoundation/Utils/JSTypedArray+Conversions.swift
@@ -18,7 +18,7 @@ extension Data {
     func blob() -> JSObject {
         let typedArray = JSTypedArray(self)
         let blobConstructor = JSObject.global.Blob.function!
-        let blob = blobConstructor.new(typedArray)
+        let blob = blobConstructor.new([typedArray])
         return blob
     }
 }


### PR DESCRIPTION
The [Blob constructor](https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob) expects an iterable of Array-likes and strings, which are concatenated into the blob. Before this change, the body was sent as a concatenation of the base-10 string representation of each byte (good old js :D).